### PR TITLE
Minor fix

### DIFF
--- a/snews_cs/snews_coinc.py
+++ b/snews_cs/snews_coinc.py
@@ -454,6 +454,7 @@ class CoincDecider:
                 if '_id' not in snews_message.keys():
                     click.secho(f"Attempted to submit a message that does not follow "
                                 f"snews_pt convention. \nThis is not supported now", fg='red')
+                    continue
 
                 # if it is a reset message, reset and continue
                 if snews_message['_id'].split('_')[0] == 'hard-reset':

--- a/snews_cs/snews_coinc.py
+++ b/snews_cs/snews_coinc.py
@@ -481,4 +481,3 @@ class CoincDecider:
                 else:
                     click.secho(f"Attempted to submit a message that does not follow "
                                 f"snews_pt convention. \nThis is not supported now", fg='red')
-                    print(f"Message id received; \n{snews_message['_id']}\n")

--- a/snews_cs/snews_coinc.py
+++ b/snews_cs/snews_coinc.py
@@ -434,7 +434,7 @@ class CoincDecider:
 
     # ------------------------------------------------------------------------------------------------------------------
     def run_coincidence(self):
-        '''
+        """
         As the name states this method runs the coincidence system.
         Starts by subscribing to the hop observation_topic.
         Filters out any messages that don't belong to either CoincidenceTier or Retraction.
@@ -444,13 +444,17 @@ class CoincDecider:
         * IF a hard-reset is passed then cache is reset.
 
 
-        '''
+        """
 
         stream = Stream(until_eos=False)
         with stream.open(self.observation_topic, "r") as s:
             print('Nothing here, please wait...')
             for snews_message in s:
                 #  Check for Coincidence
+                if '_id' not in snews_message.keys():
+                    click.secho(f"Attempted to submit a message that does not follow "
+                                f"snews_pt convention. \nThis is not supported now", fg='red')
+
                 # if it is a reset message, reset and continue
                 if snews_message['_id'].split('_')[0] == 'hard-reset':
                     self.reset_df()


### PR DESCRIPTION
This PR first checks if the received message has an `"_id"` key, if not, it complains about message not being sent via `snews_pt`
Then, it looks if this id refers to any of our tiers, retraction, or hard-reset. 
If there is an `"_id"` field but does not look like anything we generate with snews_pt, it again complains