### PR TITLE
Remote command handling

### DIFF
--- a/snews_cs/auxiliary/test-config.env
+++ b/snews_cs/auxiliary/test-config.env
@@ -1,4 +1,4 @@
-TIME_STRING_FORMAT="%y/%m/%d %H:%M:%S"
+TIME_STRING_FORMAT="%y/%m/%d %H:%M:%S:%f"
 DATABASE_SERVER="mongodb+srv://DB_User:snewsdb@THECLUSTER.surxv.mongodb.net/Database?retryWrites=true&w=majority"
 LOCAL_SERVER="mongodb://localhost:27017"
 SLACK_TOKEN=''

--- a/snews_cs/cs_utils.py
+++ b/snews_cs/cs_utils.py
@@ -24,9 +24,9 @@ def set_env(env_path=None):
 
 
 class TimeStuff:
-    ''' SNEWS format datetime objects
+    """ SNEWS format datetime objects
 
-    '''
+    """
 
     def __init__(self, env_path=None):
         set_env(env_path)
@@ -113,7 +113,8 @@ def is_garbage_message(snews_message):
 
     """
     time = TimeStuff()
-    with open('snews_cs/auxiliary/detector_properties.json') as file:
+    detector_file = os.path.abspath(os.path.join(os.path.dirname(__file__), 'auxiliary/detector_properties.json'))
+    with open(detector_file) as file:
         snews_detectors = json.load(file)
     snews_detectors = list(snews_detectors.keys())
     message_key = snews_message.keys()
@@ -183,3 +184,18 @@ def is_garbage_message(snews_message):
         return is_garbage
 
     return is_garbage
+
+def test_connection(message, broker):
+    """ When received a test_connection key
+        reinstert the message with updated status
+        this way user can test if their message
+        goes and comes back from the server
+    """
+    from hop import Stream
+    stream = Stream(until_eos=False)
+    with stream.open(broker, "w") as s:
+        # insert back with a "received" status
+        message["status"] = "received"
+        s.write(message)
+        print(message)
+        print(f"{message['name']} tested their connection {message['time']}")

--- a/snews_cs/cs_utils.py
+++ b/snews_cs/cs_utils.py
@@ -327,4 +327,17 @@ class CommandHandler:
             log = click.style(f"{self.entry()} tried to change the broker but it is not implemented")
         else:
             log = click.style(f"{self.entry()} tried to change the broker.")
-        raise NotImplementedError
+        print(log)
+        # raise NotImplementedError # do not crash the server
+        return False
+
+    def display_logs(self):
+        auth = self._check_rights()
+        new_broker_name = self.input_message["_id"]
+        if auth:
+            log = click.style(f"{self.entry()} tried to display the logs but it is not implemented")
+        else:
+            log = click.style(f"{self.entry()} tried to display the logs.")
+        print(log)
+        return False
+

--- a/snews_cs/cs_utils.py
+++ b/snews_cs/cs_utils.py
@@ -98,7 +98,7 @@ def data_cs_alert(p_vals=None, nu_times=None,
     return dict(zip(keys, values))
 
 
-def is_garbage_message(snews_message):
+def is_garbage_message(snews_message, is_test=False):
     """ This method checks to see if message meets SNEWS standards
 
     Parameters
@@ -175,9 +175,12 @@ def is_garbage_message(snews_message):
         is_garbage = True
 
     if (time.str_to_datetime(snews_message['neutrino_time']) - datetime.utcnow()).total_seconds() > 0:
-        warning += f'* neutrino time comes from the future, please stop breaking causality'
-        shitty_nu_time = True
-        is_garbage = True
+        if is_test:
+            pass
+        else:
+            warning += f'* neutrino time comes from the future, please stop breaking causality'
+            shitty_nu_time = True
+            is_garbage = True
 
     if shitty_nu_time:
         print(warning)
@@ -197,5 +200,4 @@ def test_connection(message, broker):
         # insert back with a "received" status
         message["status"] = "received"
         s.write(message)
-        print(message)
-        print(f"{message['name']} tested their connection {message['time']}")
+        print(f"> {message['time']} -> {message['name']} tested their connection")

--- a/snews_cs/snews_coinc.py
+++ b/snews_cs/snews_coinc.py
@@ -494,6 +494,7 @@ class CoincDecider:
             print(f'Running Coincidence System for {self.observation_topic}\n'
                   f'Nothing here, please wait...')
             for snews_message in s:
+                is_test = False
                 #  Check for Coincidence
                 # check if the message contains "_id", otherwise following checks crash
                 if "_id" not in snews_message.keys():
@@ -507,13 +508,18 @@ class CoincDecider:
                     else:
                         continue
 
+                # testing scenarios, bypass garbage check if it is a test
+                if "meta" in snews_message.keys():
+                    if "testing" in snews_message["meta"].keys():
+                        is_test = True
+
                 # if it is a reset message, reset and continue
                 if snews_message['_id'].split('_')[0] == 'hard-reset':
                     self.check_rights(snews_message)
                     continue
 
                 # Check for Retraction (NEEDS WORK)
-                elif snews_message['_id'].split('_')[1] == 'Retraction':
+                if snews_message['_id'].split('_')[1] == 'Retraction':
                     if snews_message['which_tier'] == 'CoincidenceTier' or snews_message['which_tier'] == 'ALL':
                         snews_message['received_time'] = datetime.utcnow().strftime("%y/%m/%d %H:%M:%S:%f")
                         self._retract_from_cache(snews_message)
@@ -523,7 +529,7 @@ class CoincDecider:
 
 # --------------------------------- main purpose (coincidence) checks after here ---------------------------------------
                 # only check if they are garbage when they are intended to be observation
-                if is_garbage_message(snews_message):
+                if is_garbage_message(snews_message, is_test):
                     print('\nMessage will not be added to cache\n'
                           'Please make sure your message follows the SNEWS-PT format')
                     continue

--- a/snews_cs/snews_coinc.py
+++ b/snews_cs/snews_coinc.py
@@ -433,7 +433,11 @@ class CoincDecider:
         click.secho(f'{"NEW COINCIDENT DETECTOR.. ".upper():^100}\n', bg='bright_green', fg='red')
         click.secho(f'{"Published an Alert!!!".upper():^100}\n', bg='bright_green', fg='red')
         click.secho(f'{"=" * 100}', fg='bright_red')
-        # snews_bot.send_table(self.cache_df, self.is_test)
+        try:
+            snews_bot.send_table(self.cache_df, self.is_test)
+        except:
+            print("Bot failed to send slack message")
+            pass
 
     # ------------------------------------------------------------------------------------------------------------------
     def dump_old_messages(self, message):


### PR DESCRIPTION
This PR goes on top of #19 

- fix default snews time string format
- Added a Remote Command Handler
    - This takes the message from the stream; 
    - checks the format (if it has `'_id'`) 
    - checks if the id field corresponds to a CoincidenceTier message, Retraction, Cache Reset, Testing message, Connection Tester
    - if it is a cache reset, checks if the user has the correct password, and only then resets the cache
    - retraction, resetting, and connection test all happen in a separate script. The `snews_coinc.py` only handles the coincidence logic.
    - The handler also handles the test scenarios. i.e. if they are submitted from `snews_pt run-scenarios` it ignores the fact that they come from the future.

Note:
When we have actual broker that we will use. We should keep the test broker open for testing purposes. Then, the test publications should go to that broker. 