### PR TITLE
Fix mail and test

### DIFF
--- a/snews_cs/cs_email.py
+++ b/snews_cs/cs_email.py
@@ -67,7 +67,7 @@ def send_feedback_mail(detector, attachment, message_content=None, given_contact
             time = datetime.utcnow().isoformat()
             mail_regular = base_msg.format(message_content=message_content,
                                            timenow=time,
-                                           attachment=attachment,
+                                           attachment=os.path.join(beats_path, attachment),
                                            contact=contact)
             log.info(f"\t\t> Trying to send feedback to {contact} for {detector}")
             out = _mail_sender([mail_regular])

--- a/snews_cs/cs_remote_commands.py
+++ b/snews_cs/cs_remote_commands.py
@@ -83,18 +83,17 @@ class Commands:
         default_connection_topic = "kafka://kafka.scimma.org/snews.connection-testing"
         connection_broker = os.getenv("CONNECTION_TEST_TOPIC", default_connection_topic)
         # it might be the second bounce, if so, log and exit
-        if message["status"] == "received":
-            log.debug("\t> Confirm Received.")
-            return None
+        # if message["status"] == "received":
+        #     log.debug("\t> Confirm Received.")
+        #     return None
 
         from hop import Stream
         stream = Stream(until_eos=True)
-        # with stream.open(CoincDeciderInstance.observation_topic, "w") as s:
+        msg = message.copy()
+        msg["status"] = "received"
         with stream.open(connection_broker, "w") as s:
             # insert back with a "received" status
-            msg = message.copy()
-            msg["status"] = "received"
-            s.write(msg)
+            s.write(JSONBlob(msg))
             log.info(f"\t> Connection Tested. 'Received' message is reinserted to connection stream.")
 
     def hard_reset(self, message, CoincDeciderInstance):


### PR DESCRIPTION
- I converted the attachment file name to the correct full-path.
- On Kafka I created the correct topic kafka://kafka.scimma.org/snews.connection-testing
- I also removed old `if status==received` bloke as that is no longer sent to the coincidence broker i.e. it'll never see it.
- wrapped the message with JSONBlob to be inline with the latest hop version