### PR TITLE
Path fixes

### DIFF
--- a/snews_cs/core/logging.py
+++ b/snews_cs/core/logging.py
@@ -22,7 +22,7 @@ from logging import (
 HOST = gethostname()
 
 log_date = date.today().strftime("%Y-%m-%d")
-log_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../logs")
+log_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../logs"))
 
 log_file = f"{log_dir}/{log_date}.log"
 fh = FileHandler(log_file)

--- a/snews_cs/cs_email.py
+++ b/snews_cs/cs_email.py
@@ -4,12 +4,12 @@
 import os, json
 from datetime import datetime
 from .core.logging import getLogger
+from .snews_hb import beats_path
 
 log = getLogger(__name__)
 
 sender = os.getenv("snews_sender_email")
 password = os.getenv("snews_sender_pass")
-beats_path = os.path.join(os.path.dirname(__file__), "../beats")
 
 contact_list_file = os.path.abspath(os.path.join(os.path.dirname(__file__), 'auxiliary/contact_list.json'))
 with open(contact_list_file) as file:
@@ -46,12 +46,6 @@ def _mail_sender(mails):
         return False
 
 ### FEEDBACK EMAIL
-# base_msg = "echo {message_content} | " \
-#            "s-nail " \
-#            "-a {attachment} "\
-#            "-s 'SNEWS FEEDBACK {timenow}' " \
-#            "{contact}"
-
 def send_feedback_mail(detector, attachment=None, message_content=None, given_contact=None):
     """ Send feedback email to authorized, requested users
     """

--- a/snews_cs/cs_remote_commands.py
+++ b/snews_cs/cs_remote_commands.py
@@ -6,6 +6,7 @@ import pandas as pd
 from .heartbeat_feedbacks import check_frequencies_and_send_mail, delete_old_figures
 from .core.logging import getLogger
 from hop.models import JSONBlob
+from .snews_hb import beats_path
 
 log = getLogger(__name__)
 
@@ -31,9 +32,7 @@ contact_list_file = os.path.abspath(os.path.join(os.path.dirname(__file__), 'aux
 with open(contact_list_file) as file:
     contact_list = json.load(file)
 
-# this csv file is mirroring the existing heartbeat cache
-beats_path = os.path.join(os.path.dirname(__file__), "../beats")
-csv_path = os.path.join(beats_path, f"cached_heartbeats_mirror.csv")
+
 
 # should I allow people to change their passwords? I can use simple encryption: from cryptography.fernet import Fernet
 class Commands:

--- a/snews_cs/snews_hb.py
+++ b/snews_cs/snews_hb.py
@@ -18,9 +18,9 @@ with open(detector_file) as file:
     snews_detectors = json.load(file)
 snews_detectors = list(snews_detectors.keys())
 
-beats_path = os.path.join(os.path.dirname(__file__), "../beats")
-mirror_csv = os.path.join(beats_path, f"cached_heartbeats_mirror.csv")
-master_csv = os.path.join(beats_path, f"complete_heartbeat_log.csv")
+beats_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../beats"))
+mirror_csv = os.path.abspath(os.path.join(beats_path, f"cached_heartbeats_mirror.csv"))
+master_csv = os.path.abspath(os.path.join(beats_path, f"complete_heartbeat_log.csv"))
 
 def get_data_strings(df_input):
     """ Convert datetime objects to strings


### PR DESCRIPTION
The app looks at different paths when invoked within different scripts. To fix that, I set the paths only in the `snews_hb.py` file and imported from this in the other files. <br>

Furthermore, I wrapped the paths with `os.path.abspath()` to avoid relative paths. <br>

While this is a temporary patch, as suggested by Chris, we should put all the paths in the -preferably- environment file.  