### PR TITLE
Use abs of nu delta_t when determining coincidence.

### DIFF
--- a/snews_cs/snews_coinc.py
+++ b/snews_cs/snews_coinc.py
@@ -121,9 +121,9 @@ class CacheManager:
             #  reset the index, for the sake of keeping things organized
             sub_cache = sub_cache.reset_index(drop=True)
             # select the initial nu time of the sub group
-            sub_ini_t = sub_cache['neutrino_time_as_datetime'][0]
+            sub_ini_t = sub_cache['neutrino_time_as_datetime'].min()
             #  make the nu time delta series
-            delta = (message['neutrino_time_as_datetime'] - sub_ini_t).total_seconds()
+            delta = abs(message['neutrino_time_as_datetime'] - sub_ini_t).total_seconds()
             #  if the message's nu time is within the coincidence window
             if 0 < delta <= 10.0:
                 # to the message add the corresponding sub group and nu time delta


### PR DESCRIPTION
@KaraMelih reported a bug in #74 where an out-of-order coincidence resulted in a test alert not being issued.

The cause is due to how the neutrino time-deltas between the new message and the sub-group cache records are calculated in `snews_coinc.py:_check_coinc_in_subgroups`. The new message is compared to the first record in the cache, and considered coincident if the neutrino time delta is in the range (0, 10] seconds.

Example: Let's say the cache already has a record with neutrino time 13:00:08 and a new message comes in for an earlier neutrino time, say 13:00:02. The neutrino time delta would be -6 seconds, which fails the coincidence check.

This solution uses the absolute value of the neutrino time delta, so that the order in which messages were received does not matter. It also compares the new message time to the earliest time in the cache, rather than the first one, since the time-ordering of records in the cache is not guaranteed.

Resolves #74.