### PR TITLE
minor compatibility fix

### DIFF
--- a/snews_cs/cs_remote_commands.py
+++ b/snews_cs/cs_remote_commands.py
@@ -212,10 +212,14 @@ class CommandHandler:
         else:
             # if passed, there has to be an _id field
             log.info(f"\t> Message is in SnewsFormat. '_id':{self.input_message['_id']} ")
-            try:
-                self.is_test = self.input_message['is_test']
-            except:
+            # temporary fix for the test messages
+            if "meta" in self.input_message.keys():
                 self.is_test = self.input_message['meta'].get('is_test', False)
+            else:
+                if "is_test" in self.input_message.keys():
+                    self.is_test = self.input_message['is_test']
+                else:
+                    self.is_test = False
             log.info(f"\t> Received Message is {'NOT ' if not self.is_test else ''}a test message!")
 
         # check what the _id field specifies


### PR DESCRIPTION
This is the issue that we discussed on the meeting today (2023/11/10) <br>

With the upcoming changes in the snews pt ( https://github.com/SNEWS2/SNEWS_Publishing_Tools/pull/81 ) we need to handle the `"meta"` field. For now, I just made a temporary fix so that it defaults to message being "non-test" in case it cannot find the `"meta"` field or the `"is_test"` field