### PR TITLE
Add ReadTheDocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,30 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+  jobs:
+    pre_install:
+      - git update-index --assume-unchanged environment.yml doc/conf.py
+    post_create_environment:
+      # Install poetry
+      # https://python-poetry.org/docs/#installing-manually
+      - pip install poetry
+      # Tell poetry to not use a virtual environment
+      - poetry config virtualenvs.create false
+    post_install:
+      # Install dependencies with 'docs' dependency group
+      # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
+      - poetry install --with docs
+
+sphinx:
+  configuration: doc/conf.py
+
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: doc/requirements.txt


### PR DESCRIPTION
Docs build is failing because of a missing `.readthedocs.yaml` config file. This PR adds a basic one.

Not sure how to test this, but RTD says there's a way to enable builds on pull request: https://docs.readthedocs.io/en/stable/guides/pull-requests.html