### PR TITLE
New unit tests

### DIFF
--- a/docs/user/Developers.md
+++ b/docs/user/Developers.md
@@ -149,3 +149,8 @@ detector3 = {'neutrino_time': "01/01/2022 12:30:11:000000"}
 In reality, Supernova time window is expected to be much smaller than 10 seconds, thus it is already a conservative time boundary. However, we wanted to have a stable and bullet proof logic that could also prove useful during stres tests and firedrills.
 
 All the observation messages are kept in cache for 24 hours after their `neutrino_time` and unless they are involved in any coincidence they are discarded. These messages together with the triggered alert messages are also locally stored in the Purdue servers through a Mongo Database connection.
+
+# 3) Notes
+
+The dependency to the snews_pt is fixed by setting the pyproject.toml file. It now points to the main branch of the snews_pt github repository.
+Therefore, the latest changes in the snews_pt repository will be automatically installed when the snews_cs is installed.

--- a/snews_cs/snews_format_checker.py
+++ b/snews_cs/snews_format_checker.py
@@ -48,7 +48,7 @@ def is_valid_iso_utc(text):
     return True
 
 # Check if detector name is in registered list.
-detector_file = os.path.abspath(os.path.join(os.path.dirname(__file__), 'auxiliary/detector_properties.json'))
+detector_file = os.path.abspath(os.path.join(os.path.dirname(__file__), 'etc/detector_properties.json'))
 with open(detector_file) as file:
     snews_detectors = json.load(file)
 snews_detectors = list(snews_detectors.keys())

--- a/snews_cs/test/test_02_alert.py
+++ b/snews_cs/test/test_02_alert.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+""" Initialization unit tests for the snews_cs alert tests
+"""
+
+import unittest
+from snews_cs.snews_coinc import CoincidenceDistributor
+import os
+from snews_pt.messages import SNEWSMessageBuilder
+from snews_pt.remote_commands import reset_cache
+from hop import Stream
+from hop.io import StartPosition
+
+
+
+class TestServer(unittest.TestCase):
+    def test_alerts(self):
+        coin1 = SNEWSMessageBuilder(detector_name='KamLAND', machine_time='2012-06-09T15:30:00.000501',
+                                    neutrino_time='2012-06-09T15:31:08.891011',
+                                    firedrill_mode=False, p_val=0.98, is_test=True)
+
+        coin2 = SNEWSMessageBuilder(detector_name='XENONnT', machine_time='2012-06-09T15:30:00.000501',
+                                    neutrino_time='2012-06-09T15:31:07.465011',
+                                    firedrill_mode=False, p_val=0.98, is_test=True)
+        # make sure the test cache is empty
+        reset_cache(is_test=True)
+
+        # First, send two coinciding messages
+        for coin in [coin1, coin2]:
+            try:
+                coin.send_messages()
+            except Exception as exc:
+                print('test_alert test failed trying to send messages with SNEWSMessageBuilder.send_messages() !\n')
+                assert False, f"Exception raised:\n {exc}"
+
+        # we need to think of a way for github actions to run the server
+        # coincidence_searcher = CoincidenceDistributor(env_path='/etc/test-config.env', firedrill_mode=False, server_tag='test')
+
+        # Next, manually open the stream and search for coincidences
+        # this tests the coincidence logic ALREADY RUNNING on the server
+        default_connection_topic = "kafka://kafka.scimma.org/snews.connection-testing"
+        test_alert_topic = os.getenv("CONNECTION_TEST_TOPIC", default_connection_topic)
+
+        _start_at = StartPosition.LATEST #if start_at=="LATEST" else StartPosition.EARLIEST
+        substream = Stream(until_eos=True, auth=True, start_at=_start_at)
+
+        message_expected = {"False Alarm Prob": "N/A",
+                            "_id": "SNEWS_Coincidence_ALERT XXXXXXXXXXX",
+                            "alert_type": "TEST COINC_MSG",
+                            "detector_names": ["KamLAND", "XENONnT"],
+                            "neutrino_times": ["2012-06-09T15:31:08.891011000", "2012-06-09T15:31:07.465011000"],
+                            "p_values": [0.98, 0.98],
+                            "p_values average": 0.98,
+                            "sent_time": "XXXXXXX",
+                            "server_tag": "XXXXXXXX",
+                            "sub list number": 0}
+
+        fields_must_match = ["False Alarm Prob", "alert_type", "detector_names", "neutrino_times", "p_values", "p_values average"]
+
+        with substream.open(test_alert_topic, "r") as ss:
+            for read in ss:
+                read = read.content
+                for field in fields_must_match:
+                    self.assertTrue(read[field] == message_expected[field], f"Field {field} does not match!")
+
+        # clear the cache again afterwards
+        reset_cache(is_test=True)


### PR DESCRIPTION
Now that the parallel cache logic is implemented and the snews_pt dependency issues are resolved, we can actually start writing smart tests.

I created this branch and started with the alert-triggering test. 
Notice that this test still sends the messages to the server running at Purdue, and manually looks into the test connection topic to see if the alert was triggered by the server. Therefore, while it tests the connection, we actually need to think of a better way to test coincidence script. This might require asynchronous job