### PR TITLE
Support test connection

### DIFF
--- a/snews_cs/cs_remote_commands.py
+++ b/snews_cs/cs_remote_commands.py
@@ -90,7 +90,7 @@ class Commands:
 
         stream = Stream(until_eos=True)
         msg = message.copy()
-        msg["status"] = "received"
+        msg["meta"]["status"] = "received"
         with stream.open(connection_broker, "w") as s:
             # insert back with a "received" status
             s.write(JSONBlob(msg))

--- a/snews_cs/snews_format_checker.py
+++ b/snews_cs/snews_format_checker.py
@@ -47,11 +47,11 @@ class SnewsFormat:
         try:
             assert self.check_id() is True, "id not valid"  # if id exists
             assert (
-                self.check_detector() is True
-            ), "detector_name not valid"  # if detector name is known
-            assert (
                 self.check_message_type() is True
             ), "types not valid"  # if valid type; check name and times
+            assert (
+                self.check_detector() is True
+            ), "detector_name not valid"  # if detector name is known
             assert (
                 self.check_times() is True
             ), "neutrino_time not valid"  # if times are ISO format and reasonable
@@ -97,8 +97,6 @@ class SnewsFormat:
 
     def check_id(self):
         """check if the id is correct
-        snews_pt sends messages in mongodb format
-        which has ti contain an id field
         """
         self.log.debug("\t> Checking id ..")
         if "id" not in self.message_keys:


### PR DESCRIPTION
- Support snews-data-formats in test-connection command
- Support empty detector names in test-connection: Format checker will bypass the detector name check if it's a test-connection command type