### PR TITLE
Implement logging over kafka

### DIFF
--- a/snews_cs/core/logging.py
+++ b/snews_cs/core/logging.py
@@ -1,16 +1,17 @@
 """
-Modified version of Geoffrey Letner's python 201 logger.
+Modified version of Geoffrey Lentner's python 201 logger.
 
 Ref: https://python-tutorial.dev/201/tutorial/logging.html
 """
-
 import os
 import time
 from datetime import date
 from socket import gethostname
+from hop import Stream
 from logging import (
     getLogger,
     NullHandler,
+    Handler,
     Formatter,
     FileHandler,
     DEBUG,
@@ -19,11 +20,18 @@ from logging import (
     ERROR,
     CRITICAL,
 )
+from . import cs_utils
+
+cs_utils.set_env(env_path)
+broker = os.getenv("HOP_BROKER")
+topic = os.getenv("SNEWPLOG_TOPIC")
 
 HOST = gethostname()
-
 log_date = date.today().strftime("%Y-%m-%d")
-log_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../logs"))
+log_dir = os.getenv('SNEWSLOG_DIR')
+
+if not log_dir:
+    log_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../logs"))
 
 log_file = f"{log_dir}/snews_cs.log"
 
@@ -35,7 +43,13 @@ if not os.path.exists(log_dir):
 if not os.path.isfile(log_file):
     open(log_file, "w").close()
 
+# These should be exclusive, one or the other: fh or klh.
+log_file = f"{log_dir}/snews_cs.log"
 fh = FileHandler(log_file)
+#
+klh = SNEWPlog(broker, topic, auth=True)
+#
+
 
 formatter = Formatter(
     f"%(asctime)s on {HOST}\n" f"  %(levelname)s [%(name)s] %(message)s",
@@ -64,3 +78,25 @@ def initialize_logging(level):
         logger.addHandler(fh)
         logger.setLevel(levels.get(level))
         logger.propagate = False
+
+
+class SNEWPlog(logging.Handler):
+    """ Implement logging over kafka topic
+    """
+
+    def __init__(self, host: str, topic: str, auth: str=None):
+        logging.Handler.__init__(self)
+        self.auth = auth
+        uri = f"{host}/{topic}"
+        self.producer = Stream(until_eos=True, auth=self.auth).open(uri, "w")
+
+    def emit(self, record):
+        if 'kafka.' in record.name:
+            return
+
+        msg = self.format(record)
+        self.producer.write(msg)
+
+    def close(self):
+        self.producer.close()
+        logging.Handler.close(self)

--- a/snews_cs/core/logging.py
+++ b/snews_cs/core/logging.py
@@ -3,6 +3,7 @@ Modified version of Geoffrey Lentner's python 201 logger.
 
 Ref: https://python-tutorial.dev/201/tutorial/logging.html
 """
+
 import os
 import time
 from datetime import date
@@ -30,10 +31,12 @@ logtopic = os.getenv("SNEWPLOG_TOPIC")
 
 HOST = gethostname()
 log_date = date.today().strftime("%Y-%m-%d")
-log_dir = os.getenv('SNEWSLOG_DIR')
+log_dir = os.getenv("SNEWSLOG_DIR")
 
 if not log_dir:
-    log_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../logs"))
+    log_dir = os.path.abspath(
+        os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../logs")
+    )
 
 log_file = f"{log_dir}/snews_cs.log"
 
@@ -49,26 +52,28 @@ if not os.path.isfile(log_file):
 log_file = f"{log_dir}/snews_cs.log"
 fh = FileHandler(log_file)
 
-class SNEWPlog(Handler):
-    """ Implement logging over kafka topic
-    """
 
-    def __init__(self, topic: str, auth: str=None):
+class SNEWPlog(Handler):
+    """Implement logging over kafka topic"""
+
+    def __init__(self, topic: str, auth: str = None):
         Handler.__init__(self)
         self.auth = auth
         self.uri = topic
-        if 'kafka://' not in topic:
+        if "kafka://" not in topic:
             self.uri = f"kafka://{topic}"
 
         try:
-            self.producer = Stream(until_eos=True, auth=self.auth).open(self.uri, "w")
+            self.producer = Stream(until_eos=True, auth=self.auth).open(
+                self.uri, "w"
+            )
         except ValueError as e:
             print(f"Problem establishing Kafka log connection: {e}")
         except Exception as e:
             print(f"Problem establishing Kafka log connection: {e}")
 
     def emit(self, record):
-        if 'kafka.' in record.name:
+        if "kafka." in record.name:
             return
 
         msg = self.format(record)
@@ -81,6 +86,7 @@ class SNEWPlog(Handler):
         if self.producer:
             self.producer.close()
         Handler.close(self)
+
 
 print(f"Initializing SNEWPlog with uri {logtopic}")
 klh = SNEWPlog(logtopic, auth=True)
@@ -109,7 +115,7 @@ levels = {
 def initialize_logging(level):
     """Initialize top-level logger with the file handler and a `level`."""
     if fh not in logger.handlers:
-        logger.addHandler(fh)   # file
+        logger.addHandler(fh)  # file
         logger.setLevel(levels.get(level))
         logger.propagate = False
 

--- a/snews_cs/core/logging.py
+++ b/snews_cs/core/logging.py
@@ -8,6 +8,8 @@ import time
 from datetime import date
 from socket import gethostname
 from hop import Stream
+from hop.models import Blob
+
 from logging import (
     getLogger,
     NullHandler,
@@ -20,11 +22,11 @@ from logging import (
     ERROR,
     CRITICAL,
 )
-from . import cs_utils
 
-cs_utils.set_env(env_path)
-broker = os.getenv("HOP_BROKER")
-topic = os.getenv("SNEWPLOG_TOPIC")
+from .. import cs_utils
+
+cs_utils.set_env()
+logtopic = os.getenv("SNEWPLOG_TOPIC")
 
 HOST = gethostname()
 log_date = date.today().strftime("%Y-%m-%d")
@@ -46,10 +48,43 @@ if not os.path.isfile(log_file):
 # These should be exclusive, one or the other: fh or klh.
 log_file = f"{log_dir}/snews_cs.log"
 fh = FileHandler(log_file)
-#
-klh = SNEWPlog(broker, topic, auth=True)
-#
 
+class SNEWPlog(Handler):
+    """ Implement logging over kafka topic
+    """
+
+    def __init__(self, topic: str, auth: str=None):
+        Handler.__init__(self)
+        self.auth = auth
+        self.uri = topic
+        if 'kafka://' not in topic:
+            self.uri = f"kafka://{topic}"
+
+        try:
+            self.producer = Stream(until_eos=True, auth=self.auth).open(self.uri, "w")
+        except ValueError as e:
+            print(f"Problem establishing Kafka log connection: {e}")
+        except Exception as e:
+            print(f"Problem establishing Kafka log connection: {e}")
+
+    def emit(self, record):
+        if 'kafka.' in record.name:
+            return
+
+        msg = self.format(record)
+        try:
+            self.producer.write(Blob(msg))
+        except Exception as e:
+            print(f"Problem writing to Kafka log stream: {e}")
+
+    def close(self):
+        if self.producer:
+            self.producer.close()
+        Handler.close(self)
+
+print(f"Initializing SNEWPlog with uri {logtopic}")
+klh = SNEWPlog(logtopic, auth=True)
+#
 
 formatter = Formatter(
     f"%(asctime)s on {HOST}\n" f"  %(levelname)s [%(name)s] %(message)s",
@@ -57,7 +92,6 @@ formatter = Formatter(
 )
 
 formatter.converter = time.gmtime
-
 fh.setFormatter(formatter)
 
 logger = getLogger("snews_cs")
@@ -75,28 +109,11 @@ levels = {
 def initialize_logging(level):
     """Initialize top-level logger with the file handler and a `level`."""
     if fh not in logger.handlers:
-        logger.addHandler(fh)
+        logger.addHandler(fh)   # file
         logger.setLevel(levels.get(level))
         logger.propagate = False
 
-
-class SNEWPlog(logging.Handler):
-    """ Implement logging over kafka topic
-    """
-
-    def __init__(self, host: str, topic: str, auth: str=None):
-        logging.Handler.__init__(self)
-        self.auth = auth
-        uri = f"{host}/{topic}"
-        self.producer = Stream(until_eos=True, auth=self.auth).open(uri, "w")
-
-    def emit(self, record):
-        if 'kafka.' in record.name:
-            return
-
-        msg = self.format(record)
-        self.producer.write(msg)
-
-    def close(self):
-        self.producer.close()
-        logging.Handler.close(self)
+    if klh not in logger.handlers:
+        logger.addHandler(klh)  # kafka
+        logger.setLevel(levels.get(level))
+        logger.propagate = False

--- a/snews_cs/etc/test-config.env
+++ b/snews_cs/etc/test-config.env
@@ -1,5 +1,6 @@
 TIME_STRING_FORMAT="%y/%m/%d %H:%M:%S:%f"
-DATABASE_SERVER="mongodb+srv://DB_User:snewsdb@THECLUSTER.surxv.mongodb.net/Database?retryWrites=true&w=majority"
+#DATABASE_SERVER="mongodb+srv://DB_User:snewsdb@THECLUSTER.surxv.mongodb.net/Database?retryWrites=true&w=majority"
+DATABASE_SERVER="mongodb://localhost:27017"
 LOCAL_SERVER="mongodb://localhost:27017"
 
 snews_cs_admin_pass='very1secret2password'
@@ -29,3 +30,4 @@ ALERT_TOPIC="kafka://${HOP_BROKER}/snews.alert-test"
 FIREDRILL_OBSERVATION_TOPIC="kafka://${HOP_BROKER}/snews.experiments-firedrill"
 FIREDRILL_ALERT_TOPIC="kafka://${HOP_BROKER}/snews.alert-firedrill"
 CONNECTION_TEST_TOPIC="kafka://${HOP_BROKER}/snews.connection-testing"
+SNEWPLOG_TOPIC="kafka://${HOP_BROKER}/snews.operations"


### PR DESCRIPTION
This PR implements a Kafka log handler in the existing logging implementation using the Python standard logging library. 

With this change, logs will be sent to  `SNEWPLOG_TOPIC`, currently defined as `kafka://${HOP_BROKER}/snews.operations`, in addition to the `snews_cs.log` file. This feature is the first step in enabling the writing of log messages to the database via `SNEWS_DB_PIPELINE`. Log messages can then be shared more widely via the `SNEWS_Monitoring_Website` interface.

Also, the location of the `snews_cs.log` file can now be overridden using a `SNEWSLOG_DIR` environment variable.

Open questions: Do we need to control who can see specific log messages? Or are there concerns surrounding sharing log information more widely. 